### PR TITLE
Fetcher should concatenate (base + endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [frontend] - remove first message delay.
 - [frontend] - MarkDown rendering.
 - [frontend] - dark mode flickering.
+- [frontend] - Concatenate base url and endpoint correctly.
 
 ## [0.3.3] - 30.10.2024
 

--- a/frontend/src/__tests__/lib/fetcher.test.ts
+++ b/frontend/src/__tests__/lib/fetcher.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { fetcher } from "@/lib/fetcher";
+import { env } from "@/lib/env";
+
+vi.mock("@/lib/env", () => ({
+  env: {
+    NEXT_PUBLIC_BACKEND_URL: "http://example.com:1234",
+  },
+}));
+
+describe("fetcher", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Mock the global fetch
+    global.fetch = vi.fn();
+  });
+
+  test("makes a successful GET request", async () => {
+    const mockResponse = { data: "test" };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const result = await fetcher({
+      method: "GET",
+      path: "/api/test",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com:1234/api/test",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+    expect(result).toEqual(mockResponse);
+  });
+
+  test("handles path parameters correctly", async () => {
+    const mockResponse = { data: "test" };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    await fetcher({
+      method: "GET",
+      path: "/api/test/{id}",
+      pathParams: { id: 123 },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com:1234/api/test/123",
+      expect.any(Object),
+    );
+  });
+
+  test("handles query parameters correctly", async () => {
+    const mockResponse = { data: "test" };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    await fetcher({
+      method: "GET",
+      path: "/api/test",
+      queryParams: { page: 1, limit: 10 },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com:1234/api/test?page=1&limit=10",
+      expect.any(Object),
+    );
+  });
+
+  test("makes a POST request with body", async () => {
+    const mockResponse = { data: "test" };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const requestBody = { name: "test" };
+    await fetcher({
+      method: "POST",
+      path: "/api/test",
+      body: requestBody,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com:1234/api/test",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(requestBody),
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  test("throws error for failed requests", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(
+      fetcher({
+        method: "GET",
+        path: "/api/test",
+      }),
+    ).rejects.toThrow("Failed to fetch data");
+  });
+
+  test("handles backend URL with path suffix correctly", async () => {
+    // Temporarily override just the NEXT_PUBLIC_BACKEND_URL for this test
+    vi.mocked(env).NEXT_PUBLIC_BACKEND_URL = "http://example.com:1234/hello";
+
+    const mockResponse = { data: "test" };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    await fetcher({
+      method: "GET",
+      path: "/api/test",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com:1234/hello/api/test",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+
+    // Reset the URL back to original
+    vi.mocked(env).NEXT_PUBLIC_BACKEND_URL = "http://example.com:1234";
+  });
+});

--- a/frontend/src/lib/fetcher.ts
+++ b/frontend/src/lib/fetcher.ts
@@ -38,10 +38,14 @@ export async function fetcher({
     });
   }
 
-  const url = new URL(
-    processedPath,
-    isServer ? env.SERVER_SIDE_BACKEND_URL : env.NEXT_PUBLIC_BACKEND_URL,
-  );
+  const baseUrl = isServer
+    ? env.SERVER_SIDE_BACKEND_URL
+    : env.NEXT_PUBLIC_BACKEND_URL;
+  // Remove trailing slash from base and leading slash from path to avoid double slashes
+  const normalizedBase = baseUrl?.replace(/\/$/, "");
+  const normalizedPath = processedPath.replace(/^\//, "");
+
+  const url = new URL(`${normalizedBase}/${normalizedPath}`);
 
   if (queryParams) {
     Object.entries(queryParams).forEach(([key, value]) => {


### PR DESCRIPTION
Closes #100 

As described in the issue, the `URL` does not do concatenation in all cases

```javascript
(new URL("/tools/hello", "http://base-url.com/fastapi")).toString()
'http://base-url.com/tools/hello'
```