### PR TITLE
Single agentic step endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        files: ^src/
+        files: ^backend/src/
         language: system
         entry: bash -c 'cd backend && mypy src/'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Object storage + plotting logic.
 - Keywords filtering for literature search.
 - [frontend] - bugfixes.
+- One shot endpoint.
 
 ### Fixed
 - [frontend] - Parallel execution of tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Object storage + plotting logic.
 - Keywords filtering for literature search.
 - [frontend] - bugfixes.
-- One shot endpoint.
+- Single agentic step endpoint.
 
 ### Fixed
 - [frontend] - Parallel execution of tools

--- a/backend/src/neuroagent/agent_routine.py
+++ b/backend/src/neuroagent/agent_routine.py
@@ -180,17 +180,17 @@ class AgentsRoutine:
     async def astream(
         self,
         agent: Agent,
-        messages: list[Messages],
+        messages: list[Messages] | list[dict[str, Any]],
         context_variables: dict[str, Any] = {},
         model_override: str | None = None,
         max_turns: int | float = float("inf"),
     ) -> AsyncIterator[str]:
         """Stream the agent response."""
         active_agent = agent
-        content = (
+        content: list[dict[str, Any]] = (
             messages
             if isinstance(messages[0], dict)
-            else await messages_to_openai_content(messages)
+            else await messages_to_openai_content(messages)  # type: ignore
         )
         history = copy.deepcopy(content)
         init_len = len(messages)
@@ -316,7 +316,7 @@ class AgentsRoutine:
 
             # Stage the new message for addition to DB
             messages.append(
-                Messages(
+                Messages(  # type: ignore
                     order=len(messages),
                     thread_id="temp"
                     if isinstance(messages[-1], dict)
@@ -327,20 +327,20 @@ class AgentsRoutine:
                 )
             )
 
-            if not messages[-1].tool_calls:
+            if not messages[-1].tool_calls:  # type: ignore
                 yield f"e:{json.dumps(finish_data)}\n"
                 break
 
             # kick out tool calls that require HIL
             tool_calls_to_execute = [
                 tool_call
-                for tool_call in messages[-1].tool_calls
+                for tool_call in messages[-1].tool_calls  # type: ignore
                 if not tool_map[tool_call.name].hil
             ]
 
             tool_calls_with_hil = [
                 tool_call
-                for tool_call in messages[-1].tool_calls
+                for tool_call in messages[-1].tool_calls  # type: ignore
                 if tool_map[tool_call.name].hil
             ]
 
@@ -368,7 +368,7 @@ class AgentsRoutine:
                 [
                     Messages(
                         order=len(messages) + i,
-                        thread_id=messages[-1].thread_id,
+                        thread_id=messages[-1].thread_id,  # type: ignore
                         entity=Entity.TOOL,
                         content=json.dumps(tool_response),
                     )

--- a/backend/src/neuroagent/agent_routine.py
+++ b/backend/src/neuroagent/agent_routine.py
@@ -187,7 +187,11 @@ class AgentsRoutine:
     ) -> AsyncIterator[str]:
         """Stream the agent response."""
         active_agent = agent
-        content = await messages_to_openai_content(messages)
+        content = (
+            messages
+            if isinstance(messages[0], dict)
+            else await messages_to_openai_content(messages)
+        )
         history = copy.deepcopy(content)
         init_len = len(messages)
         tool_map = {tool.name: tool for tool in agent.tools}
@@ -314,7 +318,9 @@ class AgentsRoutine:
             messages.append(
                 Messages(
                     order=len(messages),
-                    thread_id=messages[-1].thread_id,
+                    thread_id="temp"
+                    if isinstance(messages[-1], dict)
+                    else messages[-1].thread_id,
                     entity=get_entity(message),
                     content=json.dumps(message),
                     tool_calls=tool_calls,

--- a/backend/src/neuroagent/app/app_utils.py
+++ b/backend/src/neuroagent/app/app_utils.py
@@ -76,12 +76,12 @@ def validate_project(
         return
 
 
-def vercel_to_openai(messages: list[ClientMessage]):
+def vercel_to_openai(messages: list[ClientMessage]) -> list[dict[str, Any]]:
     """Turn vercel messages into openai format."""
     openai_messages = []
 
     for message in messages:
-        parts = []
+        parts: list[dict[str, str | dict[str, str]]] = []
 
         parts.append({"type": "text", "text": message.content})
 
@@ -119,7 +119,7 @@ def vercel_to_openai(messages: list[ClientMessage]):
                 for tool_invocation in message.toolInvocations
             ]
 
-            openai_messages.extend(tool_results)
+            openai_messages.extend(tool_results)  # type: ignore
 
             continue
 

--- a/backend/src/neuroagent/app/routers/qa.py
+++ b/backend/src/neuroagent/app/routers/qa.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from neuroagent.agent_routine import AgentsRoutine
+from neuroagent.app.app_utils import vercel_to_openai
 from neuroagent.app.config import Settings
 from neuroagent.app.database.sql_schemas import (
     Entity,
@@ -20,12 +21,10 @@ from neuroagent.app.dependencies import (
     get_settings,
     get_starting_agent,
     get_thread,
+    get_thread_agnostic_context_variable,
 )
 from neuroagent.app.stream import stream_agent_response
-from neuroagent.new_types import (
-    Agent,
-    ClientRequest,
-)
+from neuroagent.new_types import Agent, ClientRequest, ClientRequestWithHistory
 
 router = APIRouter(prefix="/qa", tags=["Run the agent"])
 
@@ -61,12 +60,44 @@ async def stream_chat_agent(
             )
         )
     stream_generator = stream_agent_response(
-        agents_routine,
-        agent,
-        messages,
-        context_variables,
-        thread,
-        request,
+        agents_routine=agents_routine,
+        agent=agent,
+        messages=messages,
+        context_variables=context_variables,
+        thread=thread,
+        request=request,
+    )
+    return StreamingResponse(
+        stream_generator,
+        media_type="text/event-stream",
+        headers={"x-vercel-ai-data-stream": "v1"},
+    )
+
+
+@router.post("/streamed_completion")
+async def stream_agent_completion(
+    user_request: ClientRequestWithHistory,
+    request: Request,
+    agents_routine: Annotated[AgentsRoutine, Depends(get_agents_routine)],
+    agent: Annotated[Agent, Depends(get_starting_agent)],
+    context_variables: Annotated[
+        dict[str, Any], Depends(get_thread_agnostic_context_variable)
+    ],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> StreamingResponse:
+    """Run an agentic step on a provided history."""
+    if len(user_request.messages[-1].content) > settings.misc.query_max_size:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Query string has {len(user_request.messages[-1].content)} characters. Maximum allowed is {settings.misc.query_max_size}.",
+        )
+    stream_generator = stream_agent_response(
+        agents_routine=agents_routine,
+        agent=agent,
+        messages=vercel_to_openai(user_request.messages),
+        context_variables=context_variables,
+        request=request,
+        thread=None,
     )
     return StreamingResponse(
         stream_generator,

--- a/backend/src/neuroagent/app/stream.py
+++ b/backend/src/neuroagent/app/stream.py
@@ -15,7 +15,7 @@ from neuroagent.new_types import Agent
 async def stream_agent_response(
     agents_routine: AgentsRoutine,
     agent: Agent,
-    messages: list[Messages],
+    messages: list[Messages] | list[dict[str, Any]],
     context_variables: dict[str, Any],
     request: Request,
     thread: Threads | None = None,

--- a/backend/src/neuroagent/new_types.py
+++ b/backend/src/neuroagent/new_types.py
@@ -65,6 +65,41 @@ class ClientRequest(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class ClientAttachment(BaseModel):
+    """Vercel class."""
+
+    name: str
+    contentType: str
+    url: str
+
+
+class ToolInvocation(BaseModel):
+    """Vercel class for one shot chat."""
+
+    toolCallId: str
+    toolName: str
+    args: dict
+    result: str
+    # state: str
+    # step: int
+
+
+class ClientMessage(BaseModel):
+    """Vercel class for one shot chat."""
+
+    role: str
+    content: str
+    experimental_attachments: list[ClientAttachment] | None = None
+    toolInvocations: list[ToolInvocation] | None = None
+
+
+class ClientRequestWithHistory(BaseModel):
+    """Vercel class for one shot chat."""
+
+    messages: list[ClientMessage]
+    tool_selection: list[str] | None = None
+
+
 class Result(BaseModel):
     """
     Encapsulates the possible return values for an agent function.

--- a/backend/src/neuroagent/new_types.py
+++ b/backend/src/neuroagent/new_types.py
@@ -78,10 +78,10 @@ class ToolInvocation(BaseModel):
 
     toolCallId: str
     toolName: str
-    args: dict[str, str]
+    args: dict[str, Any]
     result: str
-    # state: str
-    # step: int
+
+    model_config = ConfigDict(extra="ignore")
 
 
 class ClientMessage(BaseModel):
@@ -92,12 +92,16 @@ class ClientMessage(BaseModel):
     experimental_attachments: list[ClientAttachment] | None = None
     toolInvocations: list[ToolInvocation] | None = None
 
+    model_config = ConfigDict(extra="ignore")
+
 
 class ClientRequestWithHistory(BaseModel):
     """Vercel class for one shot chat."""
 
     messages: list[ClientMessage]
     tool_selection: list[str] | None = None
+
+    model_config = ConfigDict(extra="ignore")
 
 
 class Result(BaseModel):

--- a/backend/src/neuroagent/new_types.py
+++ b/backend/src/neuroagent/new_types.py
@@ -78,7 +78,7 @@ class ToolInvocation(BaseModel):
 
     toolCallId: str
     toolName: str
-    args: dict
+    args: dict[str, str]
     result: str
     # state: str
     # step: int

--- a/backend/src/neuroagent/utils.py
+++ b/backend/src/neuroagent/utils.py
@@ -38,37 +38,36 @@ def merge_chunk(final_response: dict[str, Any], delta: dict[str, Any]) -> None:
 
 
 async def messages_to_openai_content(
-    db_messages: list[Messages] | None = None,
+    db_messages: list[Messages],
 ) -> list[dict[str, Any]]:
     """Exctract content from Messages as dictionary to pass them to OpenAI."""
     messages = []
-    if db_messages:
-        for msg in db_messages:
-            if msg.content and msg.entity == Entity.AI_TOOL:
-                # Load the base content
-                content = json.loads(msg.content)
+    for msg in db_messages:
+        if msg.content and msg.entity == Entity.AI_TOOL:
+            # Load the base content
+            content = json.loads(msg.content)
 
-                # Get the associated tool calls
-                tool_calls = await msg.awaitable_attrs.tool_calls
+            # Get the associated tool calls
+            tool_calls = await msg.awaitable_attrs.tool_calls
 
-                # Format it back into the json OpenAI expects
-                tool_calls_content = [
-                    {
-                        "function": {
-                            "arguments": tool_call.arguments,
-                            "name": tool_call.name,
-                        },
-                        "id": tool_call.tool_call_id,
-                        "type": "function",
-                    }
-                    for tool_call in tool_calls
-                ]
+            # Format it back into the json OpenAI expects
+            tool_calls_content = [
+                {
+                    "function": {
+                        "arguments": tool_call.arguments,
+                        "name": tool_call.name,
+                    },
+                    "id": tool_call.tool_call_id,
+                    "type": "function",
+                }
+                for tool_call in tool_calls
+            ]
 
-                # Assign it back to the main content
-                content["tool_calls"] = tool_calls_content
-                messages.append(content)
-            else:
-                messages.append(json.loads(msg.content))
+            # Assign it back to the main content
+            content["tool_calls"] = tool_calls_content
+            messages.append(content)
+        else:
+            messages.append(json.loads(msg.content))
 
     return messages
 

--- a/frontend/src/components/chat/chat-page.tsx
+++ b/frontend/src/components/chat/chat-page.tsx
@@ -47,7 +47,6 @@ export function ChatPage({
       Authorization: `Bearer ${session?.accessToken}`,
     },
     initialMessages,
-    experimental_throttle: 100,
     experimental_prepareRequestBody: ({ messages }) => {
       const lastMessage = messages[messages.length - 1];
       const selectedTools = Object.keys(checkedTools).filter(


### PR DESCRIPTION
Closes #183 

To test it, replace the `useChat` hook in `chat-page.tsx` with the following
```javascript
const {
    messages: messagesRaw,
    input,
    handleInputChange,
    handleSubmit,
    error,
    isLoading,
    setMessages: setMessagesRaw,
  } = useChat({
    api: `${env.NEXT_PUBLIC_BACKEND_URL}/qa/streamed_completion`,
    headers: {
      Authorization: `Bearer ${session?.accessToken}`,
    },
    initialMessages,
    experimental_throttle: 100,
    experimental_prepareRequestBody: ({ messages }) => {
      const selectedTools = Object.keys(checkedTools).filter(
        (key) => key !== "allchecked" && checkedTools[key] === true,
      );
      return { messages: messages, tool_selection: selectedTools };
    },
  });
```
With the current frontend implementation, it will still create a thread but won't store the messages. If you refresh the conversation still exists but will be empty. You can continue sending messages in this same conversation. However it does that because we decided to fire the thread creation when sending the first message. In the real frontend they will just not create the thread.

Disclaimer: Every tool related to `thread_id`, `vlab_id` or `project_id` will crash. They are not meant to be used with this endpoint.