### PR TITLE
Make s3 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort components in folder.
 - Brain region/cell hierarchies read from storage (not from local filesystem).
 - Authentication is done directly through keycloak.
+- Don't assume we run minIO by default
 
 ### Added
 - Docker compose for local development

--- a/backend/src/neuroagent/app/config.py
+++ b/backend/src/neuroagent/app/config.py
@@ -19,10 +19,10 @@ class SettingsAgent(BaseModel):
 class SettingsStorage(BaseModel):
     """Storage settings."""
 
-    endpoint_url: str = "http://localhost:9000"
+    endpoint_url: str | None = None
     bucket_name: str = "neuroagent"
-    access_key: SecretStr = SecretStr("minioadmin")
-    secret_key: SecretStr = SecretStr("minioadmin")
+    access_key: SecretStr | None = None
+    secret_key: SecretStr | None = None
     expires_in: int = 600
     brain_region_hierarchy_key: str = "shared/brainregion_hierarchy.json"
     cell_type_hierarchy_key: str = "shared/celltypes_hierarchy.json"

--- a/backend/src/neuroagent/app/dependencies.py
+++ b/backend/src/neuroagent/app/dependencies.py
@@ -256,11 +256,21 @@ def get_s3_client(
     settings: Annotated[Settings, Depends(get_settings)],
 ) -> Any:
     """Get the S3 client."""
+    if settings.storage.access_key is None:
+        access_key = None
+    else:
+        access_key = settings.storage.access_key.get_secret_value()
+
+    if settings.storage.secret_key is None:
+        secret_key = None
+    else:
+        secret_key = settings.storage.secret_key.get_secret_value()
+
     return boto3.client(
         "s3",
         endpoint_url=settings.storage.endpoint_url,
-        aws_access_key_id=settings.storage.access_key.get_secret_value(),
-        aws_secret_access_key=settings.storage.secret_key.get_secret_value(),
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
         aws_session_token=None,
         config=boto3.session.Config(signature_version="s3v4"),
     )

--- a/backend/tests/app/test_main.py
+++ b/backend/tests/app/test_main.py
@@ -11,8 +11,6 @@ def test_settings_endpoint(app_client, dont_look_at_env_file, settings):
 
     replace_secretstr = settings.model_dump()
     replace_secretstr["openai"]["token"] = "**********"
-    replace_secretstr["storage"]["secret_key"] = "**********"
-    replace_secretstr["storage"]["access_key"] = "**********"
     assert response.json() == replace_secretstr
 
 


### PR DESCRIPTION
The current `main` was written in a way that by default we use MinIO (very convenient for local development). However, now that we want to deploy on S3 I am changing the config so that by default we go to S3 (can be overridden via env var) and we use credentials provided outside of Python.

So locally to use minio, make sure 

```
NEUROAGENT_STORAGE__ENDPOINT_URL=http://localhost:9000
NEUROAGENT_STORAGE__ACCESS_KEY=minioadmin
NEUROAGENT_STORAGE__SECRET_KEY=minioadmin
```

Make sure the configuration makes it possible to swap out s3/minIO