### PR TITLE
Fix sandbox issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Make `docker build` work on ARM
+
 ## [v0.5.0] - 24.04.2025
 
 ### Fixed

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,12 +2,26 @@ FROM python:3.11
 
 ENV PYTHONUNBUFFERED=1
 
-RUN apt-get -y update
-RUN apt-get -y install curl \
-    cmake \
+RUN apt-get -y update && \
+    apt-get -y install \
+    curl \
     build-essential \
     libhdf5-dev \
-    ninja-build
+    ninja-build \
+    wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget https://github.com/Kitware/CMake/archive/refs/tags/v4.0.1.tar.gz -O cmake.tar.gz \
+    && tar xzf cmake.tar.gz \
+    && cd CMake-4.0.1 \
+    && ./bootstrap --parallel=$(nproc) \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf CMake-4.0.1 cmake.tar.gz
+
+ENV CMAKE=/usr/local/bin/cmake
+ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
+RUN which cmake && cmake --version
 
 RUN pip install --no-cache-dir --upgrade pip
 COPY ./ /code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
       - NEUROAGENT_RATE_LIMITER__REDIS_HOST=redis
       - NEUROAGENT_RATE_LIMITER__REDIS_PORT=6379
     networks:
-      - app-network
+      app-network:
+        aliases:
+          - "minio"                   # Original service name
     depends_on:
       - postgres
       - minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,7 @@ services:
       - NEUROAGENT_RATE_LIMITER__REDIS_HOST=redis
       - NEUROAGENT_RATE_LIMITER__REDIS_PORT=6379
     networks:
-      app-network:
-        aliases:
-          - "minio"                   # Original service name
+      - app-network    # Simplified network config for backend
     depends_on:
       - postgres
       - minio
@@ -71,7 +69,9 @@ services:
     volumes:
       - minio_data:/data
     networks:
-      - app-network
+      app-network:
+        aliases:
+          - "minio"    # Alias belongs here with the minio service
     command: server --console-address ":9001" /data
 
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - NEUROAGENT_RATE_LIMITER__REDIS_HOST=redis
       - NEUROAGENT_RATE_LIMITER__REDIS_PORT=6379
     networks:
-      - app-network    # Simplified network config for backend
+      - app-network
     depends_on:
       - postgres
       - minio


### PR DESCRIPTION
Closes #262 and closes #220 


- [x] Make sure presigned url (client -> minio) has a different URL then fastapi backend -> minio
- [x] Build Morphio from scratch


So for the first point, I used the concept of a network `alias` that one can add in `docker-compose` and it basically corresponds to a DNS entry that the given service will use for resolving.