### PR TITLE
Remove usage of user journey in suggestion after first message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- get morpho tool and resolve entities now uses entitycore.
+- Get morpho tool and resolve entities now uses entitycore.
+- Remove usage of user journey in suggestion after first message.
 
 ### Added
 - Autogeneration of input schemas from APIs.

--- a/backend/src/neuroagent/app/schemas.py
+++ b/backend/src/neuroagent/app/schemas.py
@@ -146,5 +146,5 @@ class QuestionsSuggestions(BaseModel):
 class QuestionsSuggestionsRequest(BaseModel):
     """Request for the suggestion endpoint."""
 
-    click_history: list[list[list[str]]]
+    click_history: list[list[list[str]]] | None = None
     thread_id: str | None = None

--- a/backend/tests/app/routers/test_qa.py
+++ b/backend/tests/app/routers/test_qa.py
@@ -96,15 +96,15 @@ def test_question_suggestions(
     call_list = mock_openai_client.beta.chat.completions.parse.call_args_list
     assert call_list[0].kwargs["messages"][1] == {
         "role": "user",
-        "content": 'USER JOURNEY: \n[[["Amzing BR", "Super artifact"]]]\n USER MESSAGES : \n',
+        "content": 'USER JOURNEY: \n[[["Amzing BR", "Super artifact"]]]',
     }
     assert call_list[1].kwargs["messages"][1] == {
         "role": "user",
-        "content": 'USER JOURNEY: \n[[["Amzing BR", "Super artifact"]]]\n USER MESSAGES : \n',
+        "content": 'USER JOURNEY: \n[[["Amzing BR", "Super artifact"]]]',
     }
     assert call_list[2].kwargs["messages"][1] == {
         "role": "user",
-        "content": 'USER JOURNEY: \n[[["Amzing BR", "Super artifact"]]]\n USER MESSAGES : \n[{"content": "This is my query."}, {"content": "sample response content."}]',
+        "content": 'CONVERSATION MESSAGES: \n[{"content": "This is my query."}, {"content": "sample response content."}]',
     }
 
 


### PR DESCRIPTION
Closes #319 

I had a discussion with Fabien, he prefers if this endpoint remains one. I do think that we should eventually split them back in two endpoints since both purposes diverge more and more.

Now the use-cases are as follow:
| thread_id/click_history        | provided                             | not provided                   |
|--------------------------------|--------------------------------------|--------------------------------|
| provided and contains messages | in chat = useless history is ignored | in chat = message history used |
| provided but empty             | not in chat click history used       | error                          |
| not provided                   | not in chat click history used       | error                          |