### PR TITLE
Expose `x-request-id` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - OBI expert points at the documentationProduct instead of documentationGithub
+- Expose the `x-request-id` header for CORS requests.
 
 ## [0.14.3] - 26.01.2026
 

--- a/backend/src/neuroagent/app/main.py
+++ b/backend/src/neuroagent/app/main.py
@@ -185,6 +185,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["x-request-id"],
 )
 app.add_middleware(
     CorrelationIdMiddleware,


### PR DESCRIPTION
So that it can be used by the frontend JS